### PR TITLE
タスク一覧表示機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 | encrypted_password | string | null: false | パスワード |
 
 has_many :groups
+has_many :tasks
 
 ### groupsテーブル（Groupモデル）
 
@@ -29,10 +30,12 @@ belongs_to :user
 | memo | text |  | タスクの補足 |
 | type_id | integer | null: false | タスクのタイプ（プルダウン） |
 | group | references | null: false, foreign_key: true | groupsテーブルの外部キー |
+| user | references | null: false, foreign_key: true | userテーブルの外部キー |
 
 has_one :finish
 has_one :priority
 belongs_to :group
+belongs_to :user
 
 ### finishesテーブル（Finishモデル）
 

--- a/app/assets/stylesheets/someday.css
+++ b/app/assets/stylesheets/someday.css
@@ -1,3 +1,11 @@
 header{
   background-color: lightyellow;
 }
+
+.group{
+  background-color: lightsteelblue;
+}
+
+.task{
+  background-color: lightcyan;
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   def index
     if user_signed_in?
       @groups = Group.where(user_id: current_user.id)
+      @tasks = Task.where(user_id: current_user.id)
     end
   end
 
@@ -22,7 +23,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:group_id, :content, :memo, :type_id)
+    params.require(:task).permit(:group_id, :content, :memo, :type_id).merge(user_id: current_user.id)
   end
 
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,8 @@
 class TasksController < ApplicationController
   def index
+    if user_signed_in?
+      @groups = Group.where(user_id: current_user.id)
+    end
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,4 +3,19 @@
   <div>index画面</div>
   <div><%= link_to "group new", new_group_path %></div>
   <div><%= link_to "task new", new_task_path %></div>
+  <% if user_signed_in? %>
+    <% @groups.each do |group| %>
+      <div class = "group">
+        <%= group.group_name %>
+        <div>
+          <%= group.group_memo %>
+          <% group.tasks.each do |task| %>
+            <div class = "task">
+              <%= task.content %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
 </main>

--- a/config/datebase.dio
+++ b/config/datebase.dio
@@ -55,6 +55,14 @@
                         <Array as="points"/>
                     </mxGeometry>
                 </mxCell>
+                <mxCell id="17" style="edgeStyle=none;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;endArrow=ERmany;endFill=0;endSize=20;startSize=20;startArrow=ERone;startFill=0;" edge="1" parent="1" source="3" target="7">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="564" y="400"/>
+                            <mxPoint x="680" y="550"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
             </root>
         </mxGraphModel>
     </diagram>

--- a/db/migrate/20240528031539_create_tasks.rb
+++ b/db/migrate/20240528031539_create_tasks.rb
@@ -4,6 +4,7 @@ class CreateTasks < ActiveRecord::Migration[7.0]
       t.string      :content, null: false
       t.text        :memo
       t.integer     :type_id, null: false
+      t.references  :user, null: false, foreign_key: true
       t.references  :group, null: false, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,10 +24,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_28_031539) do
     t.string "content", null: false
     t.text "memo"
     t.integer "type_id", null: false
+    t.bigint "user_id", null: false
     t.bigint "group_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_tasks_on_group_id"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|
@@ -45,4 +47,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_28_031539) do
 
   add_foreign_key "groups", "users"
   add_foreign_key "tasks", "groups"
+  add_foreign_key "tasks", "users"
 end


### PR DESCRIPTION
# what
タスクとグループの一覧表示をできるようにした。
これまでタスクにはユーザー情報を紐づけていなかったが、この先の利便性を考えて紐づけることにした。
だが一覧表示の場面では、結局親であるグループに連なる形にしたかったので、ここではあまり意味がない。